### PR TITLE
Fixes dockerignore for `tmp` and `log` directories when building image

### DIFF
--- a/lib/orats/templates/base/.dockerignore
+++ b/lib/orats/templates/base/.dockerignore
@@ -1,5 +1,5 @@
 .git
 .dockerignore
 .byebug_history
-/log/*
-/tmp/*
+log/*
+tmp/*


### PR DESCRIPTION
Both directories tmp and log were being copied to the docker image on build.