### PR TITLE
Upgrade Nodejs to LTS version

### DIFF
--- a/lib/orats/templates/base/Dockerfile
+++ b/lib/orats/templates/base/Dockerfile
@@ -18,8 +18,12 @@ MAINTAINER Nick Janetakis <nick.janetakis@gmail.com>
 # It is good practice to set a maintainer for all of your Docker
 # images. It's not necessary but it's a good habit.
 
+# Add Debian Testing repository in order to get access to Nodejs LTS versions
+RUN echo "deb http://http.us.debian.org/debian testing main non-free contrib" >> /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -qq -y --no-install-recommends \
-      build-essential nodejs libpq-dev
+      build-essential nodejs nodejs-legacy libpq-dev && rm -rf /var/lib/apt/lists/*
+
 # Ensure that our apt package list is updated and install a few
 # packages to ensure that we can compile assets (nodejs) and
 # communicate with PostgreSQL (libpq-dev).

--- a/lib/orats/templates/base/Dockerfile
+++ b/lib/orats/templates/base/Dockerfile
@@ -20,9 +20,10 @@ MAINTAINER Nick Janetakis <nick.janetakis@gmail.com>
 
 # Add Debian Testing repository in order to get access to Nodejs LTS versions
 RUN echo "deb http://http.us.debian.org/debian testing main non-free contrib" >> /etc/apt/sources.list
+COPY docker/apt.preferences /etc/apt/preferences
 
 RUN apt-get update && apt-get install -qq -y --no-install-recommends \
-      build-essential nodejs nodejs-legacy libpq-dev && rm -rf /var/lib/apt/lists/*
+      build-essential wget nodejs/testing nodejs-legacy/testing libpq-dev && rm -rf /var/lib/apt/lists/*
 
 # Ensure that our apt package list is updated and install a few
 # packages to ensure that we can compile assets (nodejs) and

--- a/lib/orats/templates/base/docker/apt.preferences
+++ b/lib/orats/templates/base/docker/apt.preferences
@@ -1,0 +1,11 @@
+Package: *
+Pin: release a=stable
+Pin-Priority: 700
+
+Package: *
+Pin: release a=testing
+Pin-Priority: 650
+
+Package: *
+Pin: release a=unstable
+Pin-Priority: 600


### PR DESCRIPTION
The current nodejs in debian jessie is 0.10.0, which is end-of-life and insecure.

I took a conversative approach with this PR and use the Debian Testing (stretch) repo to add the v4 LTS line, which is currently 4.7.2 from here

https://packages.debian.org/stretch/nodejs

Also added the `nodejs-legacy` symlink, and the post install apt list cleanup that people use on official images, which saves about 20mb.

Are you happy with those changes @nickjj ?