### PR TITLE
Use RedisCacheStore instead of redis store

### DIFF
--- a/lib/orats/templates/base/.env.example
+++ b/lib/orats/templates/base/.env.example
@@ -43,8 +43,8 @@ DATABASE_URL=postgresql://orats_base:yourpassword@postgres:5432/orats_base?encod
 # The full Redis URL for the Redis cache.
 REDIS_CACHE_URL=redis://:yourpassword@redis:6379/0
 
-# Namespace for Redis cache
-REDIS_NAMESPACE=cache
+# The namespace used by the Redis cache.
+REDIS_CACHE_NAMESPACE=cache
 
 # Action mailer (e-mail) settings.
 # You will need to enable less secure apps in your Google account if you plan

--- a/lib/orats/templates/base/.env.example
+++ b/lib/orats/templates/base/.env.example
@@ -40,8 +40,11 @@ POSTGRES_PASSWORD=yourpassword
 # such as: orats_base_development or orats_base_production.
 DATABASE_URL=postgresql://orats_base:yourpassword@postgres:5432/orats_base?encoding=utf8&pool=5&timeout=5000
 
-# The full Redis URL for the Redis cache. The last segment is the namespace.
-REDIS_CACHE_URL=redis://:yourpassword@redis:6379/0/cache
+# The full Redis URL for the Redis cache.
+REDIS_CACHE_URL=redis://:yourpassword@redis:6379/0
+
+# Namespace for Redis cache
+REDIS_NAMESPACE=cache
 
 # Action mailer (e-mail) settings.
 # You will need to enable less secure apps in your Google account if you plan

--- a/lib/orats/templates/base/Gemfile
+++ b/lib/orats/templates/base/Gemfile
@@ -21,7 +21,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'pg', '~> 1.0'
 
 # Use Redis Rails to set up a Redis backed Cache and / or Session
-gem 'redis-rails', '~> 5.0'
+gem 'redis', '~> 4.0'
 
 # Use Sidekiq as a background job processor through Active Job
 gem 'sidekiq', '~> 5.1'

--- a/lib/orats/templates/base/config/application.rb
+++ b/lib/orats/templates/base/config/application.rb
@@ -46,7 +46,10 @@ module OratsBase
     }
 
     # Set Redis as the back-end for the cache.
-    config.cache_store = :redis_store, ENV['REDIS_CACHE_URL']
+    config.cache_store = :redis_cache_store, {
+      url: ENV['REDIS_CACHE_URL'],
+      namespace: ENV['REDIS_NAMESPACE']
+    }
 
     # Set Sidekiq as the back-end for Active Job.
     config.active_job.queue_adapter = :sidekiq

--- a/lib/orats/templates/base/config/application.rb
+++ b/lib/orats/templates/base/config/application.rb
@@ -48,7 +48,7 @@ module OratsBase
     # Set Redis as the back-end for the cache.
     config.cache_store = :redis_cache_store, {
       url: ENV['REDIS_CACHE_URL'],
-      namespace: ENV['REDIS_NAMESPACE']
+      namespace: ENV['REDIS_CACHE_NAMESPACE']
     }
 
     # Set Sidekiq as the back-end for Active Job.


### PR DESCRIPTION
Addresses #40 

Seems to be compatible out of the box. The only issue is that namespace had to be split into its own ENV variable as it's not being picked up from the URL.

As far as I can see, if something like redis://:yourpassword@redis:6379/0/cache is used as REDIS_URL, it will still be correctly saved in db 0, but not namespaced.