### PR TITLE
Configure Rack::Timeout via env variable

### DIFF
--- a/lib/orats/templates/base/.env.example
+++ b/lib/orats/templates/base/.env.example
@@ -93,3 +93,8 @@ ACTION_CABLE_FRONTEND_URL=ws://localhost:28080
 # Not running Docker natively? Replace 'localhost' with your Docker Machine IP
 # address, such as: http:\/\/192.168.99.100*
 ACTION_CABLE_ALLOWED_REQUEST_ORIGINS=http:\/\/localhost*
+
+# Rack::Timeout aborts requests that are taking too long. 
+# After a request is aborted an exception is raised.
+# Adjust the following variable to suit your needs.
+RACK_TIMEOUT_SERVICE_TIMEOUT=5

--- a/lib/orats/templates/base/Gemfile
+++ b/lib/orats/templates/base/Gemfile
@@ -12,7 +12,7 @@ gem 'rails', '~> 5.2.0'
 gem 'puma', '~> 3.11'
 
 # Use Rack Timeout. Read more: https://github.com/heroku/rack-timeout
-gem 'rack-timeout', '~> 0.4'
+gem 'rack-timeout', '~> 0.5'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'

--- a/lib/orats/templates/base/config/initializers/timeout.rb
+++ b/lib/orats/templates/base/config/initializers/timeout.rb
@@ -1,1 +1,0 @@
-Rack::Timeout.timeout = ENV.fetch('REQUEST_TIMEOUT') { 5 }.to_i


### PR DESCRIPTION
Since Rack::Timeout 0.5.0 removed class setter for timeout variable. It is now set to 15s default and can be changed via `RACK_TIMEOUT_SERVICE_TIMEOUT` environmental variable

Closes #43