### PR TITLE
Fix error with nokogiri gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ Style/FrozenStringLiteralComment:
 Style/AlignHash:
   Enabled: false
 
- Style/PercentLiteralDelimiters:
+Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     default: ()
     '%r': '{}'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,10 @@ Documentation:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Style/PercentLiteralDelimiters:
+Style/AlignHash:
+  Enabled: false
+
+ Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     default: ()
     '%r': '{}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.5.3
 
 script:
 - 'rubocop'

--- a/lib/orats/templates/base/Dockerfile
+++ b/lib/orats/templates/base/Dockerfile
@@ -1,6 +1,14 @@
 FROM ruby:2.5-alpine
 
-RUN apk update && apk add build-base nodejs postgresql-dev
+RUN apk add --update \
+  build-base \
+  libxml2-dev \
+  libxslt-dev \
+  postgresql-dev \
+  && rm -rf /var/cache/apk/*
+
+# Use libxml2, libxslt a packages from alpine for building nokogiri
+RUN bundle config build.nokogiri --use-system-libraries
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
When trying to build I get an error: 
ERROR:  Error installing nokogiri:
        ERROR: Failed to build gem native extension.

    current directory: /usr/local/bundle/gems/nokogiri-1.8.5/ext/nokogiri
/usr/local/bin/ruby -r ./siteconf20181130-1-xr0tlz.rb extconf.rb --use-system-libraries
checking if the C compiler accepts ... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/usr/local/bin/$(RUBY_BASE_NAME)
        --help
        --clean
/usr/local/lib/ruby/2.5.0/mkmf.rb:456:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.
        from /usr/local/lib/ruby/2.5.0/mkmf.rb:574:in `block in try_compile'
        from /usr/local/lib/ruby/2.5.0/mkmf.rb:521:in `with_werror'
        from /usr/local/lib/ruby/2.5.0/mkmf.rb:574:in `try_compile'
        from extconf.rb:138:in `nokogiri_try_compile'
        from extconf.rb:162:in `block in add_cflags'
        from /usr/local/lib/ruby/2.5.0/mkmf.rb:632:in `with_cflags'
        from extconf.rb:161:in `add_cflags'
        from extconf.rb:410:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /usr/local/bundle/extensions/x86_64-linux/2.5.0/nokogiri-1.8.5/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /usr/local/bundle/gems/nokogiri-1.8.5 for inspection.
Results logged to /usr/local/bundle/extensions/x86_64-linux/2.5.0/nokogiri-1.8.5/gem_make.out
ERROR: Service 'website' failed to build: The command '/bin/sh -c gem install nokogiri -- --use-system-libraries' returned a non-zero code: 1

I found the solution here.
https://github.com/gliderlabs/docker-alpine/issues/53#issuecomment-179486583
