### PR TITLE
Extract port to separate env

### DIFF
--- a/lib/orats/templates/base/.env.example
+++ b/lib/orats/templates/base/.env.example
@@ -16,7 +16,9 @@ SECRET_TOKEN=asecuretokenwouldnormallygohere
 
 # More details about these Puma variables can be found in config/puma.rb.
 # Which address should the Puma app server bind to?
-BIND_ON=0.0.0.0:3000
+BIND_ON=0.0.0.0
+
+PORT=3000
 
 # Puma supports multiple threads but in development mode you'll want to use 1
 # thread to ensure that you can properly debug your application.

--- a/lib/orats/templates/base/config/puma.rb
+++ b/lib/orats/templates/base/config/puma.rb
@@ -1,6 +1,7 @@
 # Bind on a specific TCP address. We won't bother using unix sockets because
 # nginx will be running in a different Docker container.
-bind "tcp://#{ENV['BIND_ON']}"
+bind "tcp://#{ENV.fetch('BIND_ON')}"
+port ENV.fetch('PORT')
 
 # Puma supports threading. Requests are served through an internal thread pool.
 # Even on MRI, it is beneficial to leverage multiple threads because I/O


### PR DESCRIPTION
This makes it easier to deploy to Heroku since the `PORT` env var is dynamic on most of the tiers.

I also included the use of `Hash#fetch` to denote the 12-factor requirement of those variables in all environments.